### PR TITLE
Move values to Optional key.

### DIFF
--- a/src/main/resources/data/farmersdelight/tags/blocks/tray_heat_sources.json
+++ b/src/main/resources/data/farmersdelight/tags/blocks/tray_heat_sources.json
@@ -1,6 +1,11 @@
 {
   "replace": false,
-  "values": [
-    "endergetic:ender_campfire"
+  "values": [],
+  "optional": [
+    "endergetic:ender_campfire",
+    "infernalexp:campfire_glow",
+    "decorative_blocks:brazier",
+    "decorative_blocks:soul_brazier",
+    "decorative_blocks_abnormals:ender_brazier"
   ]
 }


### PR DESCRIPTION
The "Optional" array in a block-tag json allows soft-failure if any of the blocks aren't present, helpful for compatibility mods such as yours.

This should fix both #3 and #4 at the same time.

Also, your repo seems out of date? This makes pull requests significantly harder to write *and* merge.  
For this specific one, I had to reference the json present in the jar of the most recent curseforge release, else it would be missing some entries.  
Please consider pushing to your repository more regularly.